### PR TITLE
Get 'user' from props before Firebase call

### DIFF
--- a/src/components/account/Account.js
+++ b/src/components/account/Account.js
@@ -3,8 +3,8 @@ import { View, Text } from 'react-native';
 import Firebase from 'firebase';
 import Logout from '../auth/Logout';
 
-const Account = () => {
-  const user = Firebase.auth().currentUser; // LATER: change to props
+const Account = ({ user }) => {
+  user = user || Firebase.auth().currentUser;
 
   return (
     <View>

--- a/src/components/loved_ones/LovedOnesList.js
+++ b/src/components/loved_ones/LovedOnesList.js
@@ -9,7 +9,6 @@ import { changeLovedOnes } from '../../actions';
 class LovedOnesList extends React.Component {
   constructor(props) {
     super(props);
-    this.renderItem = this.renderItem.bind(this);
     this.fetchLovedOnes = this.fetchLovedOnes.bind(this);
   }
 
@@ -18,7 +17,8 @@ class LovedOnesList extends React.Component {
   }
 
   fetchLovedOnes() {
-    const user = Firebase.auth().currentUser; // LATER: change to props
+    let { user } = this.props;
+    user = user || Firebase.auth().currentUser;
 
     const db = Firebase.firestore();
     const lovedOnesRef = db.collection(`users/${user.uid}/lovedOnes`);
@@ -38,7 +38,7 @@ class LovedOnesList extends React.Component {
 
   renderItem = ({ item }) => (
     <LovedOnesListItem label={item.data().email} />
-  )
+  );
 
   render() {
     const { lovedOnes } = this.props;

--- a/src/components/requests/ReceivedRequestsList.js
+++ b/src/components/requests/ReceivedRequestsList.js
@@ -45,7 +45,6 @@ class ReceivedRequestsList extends React.Component {
   }
 
   addMyLovedOne(request) { // Not static yet. may use 'this' in promises
-    const { nothing } = this.props; // Just to get rid of red; remove later
     const id = request.data().requesterId;
     const email = request.data().requesterEmail;
     const date = new Date();
@@ -57,7 +56,10 @@ class ReceivedRequestsList extends React.Component {
     };
 
     const db = Firebase.firestore();
-    const user = Firebase.auth().currentUser; // LATER: change to props
+
+    let { user } = this.props;
+    user = user || Firebase.auth().currentUser;
+
     const myLovedOnesRef = db.collection(`users/${user.uid}/lovedOnes`);
 
     myLovedOnesRef.add(lovedOneDoc)
@@ -70,8 +72,8 @@ class ReceivedRequestsList extends React.Component {
   }
 
   addTheirLovedOne(request) { // Not static yet. may use 'this' in promises
-    const { nothing } = this.props;
-    const user = Firebase.auth().currentUser; // LATER: change to props
+    let { user } = this.props;
+    user = user || Firebase.auth().currentUser;
 
     const id = user.uid;
     const email = user.email;
@@ -97,7 +99,8 @@ class ReceivedRequestsList extends React.Component {
   }
 
   fetchPendingRequests() {
-    const user = Firebase.auth().currentUser; // LATER: change to props
+    let { user } = this.props;
+    user = user || Firebase.auth().currentUser;
 
     const db = Firebase.firestore();
     const requestsRef = db.collection('requests');
@@ -126,7 +129,7 @@ class ReceivedRequestsList extends React.Component {
       onAccept={() => this.onAccept(item)}
       onDecline={() => this.onDecline(item)}
     />
-  )
+  );
 
   render() {
     const { receivedRequests } = this.props;


### PR DESCRIPTION
Add functionality to extract user from props object as opposed to Firebase.auth().currentUser, which will only be called lazily in the case user is undefined. This prevents many requests to the Firebase DB when navigating tab by tab throughout the app.